### PR TITLE
Conditions WQs Twilight Highlands and Legion 

### DIFF
--- a/WorldQuests.lua
+++ b/WorldQuests.lua
@@ -30,10 +30,19 @@ local function IsLegionInvasionActive()
 	return false
 end
 
+
+local function TwilightHighlandWQsUnlocked()
+	-- "<Name>, Definitely Not a Cultist" is awarded at the end of the Midnight prepatch event intro quest chain, spanning "The Cult Within" to "Cult It Out" and unlocks WQ in Twilight Highlands for the warband for all character levels, lvl 1 Bloodelfes work, level 4 pandaren without allegiance don't.
+    local f = UnitFactionGroup("player")
+    return IsTitleKnown(643) and (f == "Alliance" or f == "Horde")
+end
+
+
+
 function BWQ:WorldQuestsUnlocked()
 	if not BWQ.hasUnlockedWorldQuests then
 		if (BWQ.expansion == CONSTANTS.EXPANSIONS.THEWARWITHIN) then
-			BWQ.hasUnlockedWorldQuests = C_QuestLog.IsQuestFlaggedCompleted(79573) -- See effect #1 under https://www.wowhead.com/spell=434027/world-quests-adventure-mode
+			BWQ.hasUnlockedWorldQuests = (C_QuestLog.IsQuestFlaggedCompleted(79573) or TwilightHighlandWQsUnlocked()) -- See effect #1 under https://www.wowhead.com/spell=434027/world-quests-adventure-mode
 		elseif (BWQ.expansion == CONSTANTS.EXPANSIONS.DRAGONFLIGHT) then
 			_, _, _, BWQ.hasUnlockedWorldQuests = GetAchievementInfo(16326)
 			if not BWQ.hasUnlockedWorldQuests then


### PR DESCRIPTION
Midnight world quests appear without any unlock quest done for TWW except maybe the intro quest to twilight highlands. There is no achievement and no quest triggers after you finished the intro quest and get your cult title.
This makes detecting world quest unlock impossible for the rest of your warband. They are independent of character level. 


The legion invasions do not require you to be in the zone to be visible.

I guess detecting the invasion area poi is better.
Also the level for remix characters does not matter if you unlock the other world quests on an alt which has the alternate uniting the isles available immediately.
